### PR TITLE
Google Maps supports battery level and charging.

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -11,13 +11,13 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
-from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify, dt as dt_util
 
-REQUIREMENTS = ['locationsharinglib==2.0.11']
+REQUIREMENTS = ['locationsharinglib==3.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,6 +94,8 @@ class GoogleMapsScanner:
                 ATTR_ID: person.id,
                 ATTR_LAST_SEEN: dt_util.as_utc(person.datetime),
                 ATTR_NICKNAME: person.nickname,
+                ATTR_BATTERY_CHARGING: person.charging,
+                ATTR_BATTERY_LEVEL: person.battery_level
             }
             self.see(
                 dev_id=dev_id,

--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
-from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL
+from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType

--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -11,8 +11,9 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
-from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.const import ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL
+from homeassistant.const import (
+    ATTR_ID, CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_CHARGING,
+    ATTR_BATTERY_LEVEL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aioimaplib==0.7.13
 aiolifx==0.6.3
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.2.0
+aiolifx_effects==0.1.2
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.5.4
@@ -172,7 +172,7 @@ beautifulsoup4==4.6.3
 bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.5.3
+bimmer_connected==0.5.2
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -338,9 +338,8 @@ eternalegypt==0.0.5
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1
 
-# homeassistant.components.evohome
 # homeassistant.components.climate.honeywell
-evohomeclient==0.2.7
+evohomeclient==0.2.5
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
@@ -491,6 +490,9 @@ ihcsdk==2.2.0
 # homeassistant.components.sensor.influxdb
 influxdb==5.0.0
 
+# homeassistant.components.insteon_plm
+insteonplm==0.11.7
+
 # homeassistant.components.insteon
 insteonplm==0.14.2
 
@@ -558,7 +560,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.device_tracker.google_maps
-locationsharinglib==2.0.11
+locationsharinglib==3.0.2
 
 # homeassistant.components.logi_circle
 logi_circle==0.1.7
@@ -765,7 +767,7 @@ pyRFXtrx==0.23
 pySwitchmate==0.4.1
 
 # homeassistant.components.sensor.tibber
-pyTibber==0.6.0
+pyTibber==0.5.1
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
@@ -795,7 +797,7 @@ pyasn1-modules==0.1.5
 pyasn1==0.3.7
 
 # homeassistant.components.netatmo
-pyatmo==1.2
+pyatmo==1.1.1
 
 # homeassistant.components.apple_tv
 pyatv==0.3.10
@@ -1015,9 +1017,6 @@ pynx584==0.4
 # homeassistant.components.openuv
 pyopenuv==1.0.4
 
-# homeassistant.components.light.opple
-pyoppleio==1.0.5
-
 # homeassistant.components.iota
 pyota==2.0.5
 
@@ -1072,7 +1071,7 @@ pysma==0.2
 pysnmp==4.4.5
 
 # homeassistant.components.sonos
-pysonos==0.0.3
+pysonos==0.0.2
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
@@ -1117,9 +1116,6 @@ python-forecastio==1.4.0
 
 # homeassistant.components.gc100
 python-gc100==1.0.3a
-
-# homeassistant.components.sensor.gitlab_ci
-python-gitlab==1.6.0
 
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aioimaplib==0.7.13
 aiolifx==0.6.3
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.1.2
+aiolifx_effects==0.2.0
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.5.4
@@ -172,7 +172,7 @@ beautifulsoup4==4.6.3
 bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.5.2
+bimmer_connected==0.5.3
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -338,8 +338,9 @@ eternalegypt==0.0.5
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1
 
+# homeassistant.components.evohome
 # homeassistant.components.climate.honeywell
-evohomeclient==0.2.5
+evohomeclient==0.2.7
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
@@ -489,9 +490,6 @@ ihcsdk==2.2.0
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==5.0.0
-
-# homeassistant.components.insteon_plm
-insteonplm==0.11.7
 
 # homeassistant.components.insteon
 insteonplm==0.14.2
@@ -767,7 +765,7 @@ pyRFXtrx==0.23
 pySwitchmate==0.4.1
 
 # homeassistant.components.sensor.tibber
-pyTibber==0.5.1
+pyTibber==0.6.0
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
@@ -797,7 +795,7 @@ pyasn1-modules==0.1.5
 pyasn1==0.3.7
 
 # homeassistant.components.netatmo
-pyatmo==1.1.1
+pyatmo==1.2
 
 # homeassistant.components.apple_tv
 pyatv==0.3.10
@@ -1017,6 +1015,9 @@ pynx584==0.4
 # homeassistant.components.openuv
 pyopenuv==1.0.4
 
+# homeassistant.components.light.opple
+pyoppleio==1.0.5
+
 # homeassistant.components.iota
 pyota==2.0.5
 
@@ -1071,7 +1072,7 @@ pysma==0.2
 pysnmp==4.4.5
 
 # homeassistant.components.sonos
-pysonos==0.0.2
+pysonos==0.0.3
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
@@ -1116,6 +1117,9 @@ python-forecastio==1.4.0
 
 # homeassistant.components.gc100
 python-gc100==1.0.3a
+
+# homeassistant.components.sensor.gitlab_ci
+python-gitlab==1.6.0
 
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -52,9 +52,8 @@ dsmr_parser==0.11
 # homeassistant.components.sensor.season
 ephem==3.7.6.0
 
-# homeassistant.components.evohome
 # homeassistant.components.climate.honeywell
-evohomeclient==0.2.7
+evohomeclient==0.2.5
 
 # homeassistant.components.feedreader
 # homeassistant.components.sensor.geo_rss_events
@@ -102,6 +101,9 @@ libpurecoollink==0.4.2
 
 # homeassistant.components.media_player.soundtouch
 libsoundtouch==0.7.2
+
+# homeassistant.components.device_tracker.google_maps
+locationsharinglib==3.0.2
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
@@ -170,7 +172,7 @@ pyotp==2.2.6
 pyqwikswitch==0.8
 
 # homeassistant.components.sonos
-pysonos==0.0.3
+pysonos==0.0.2
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -52,8 +52,9 @@ dsmr_parser==0.11
 # homeassistant.components.sensor.season
 ephem==3.7.6.0
 
+# homeassistant.components.evohome
 # homeassistant.components.climate.honeywell
-evohomeclient==0.2.5
+evohomeclient==0.2.7
 
 # homeassistant.components.feedreader
 # homeassistant.components.sensor.geo_rss_events
@@ -172,7 +173,7 @@ pyotp==2.2.6
 pyqwikswitch==0.8
 
 # homeassistant.components.sonos
-pysonos==0.0.2
+pysonos==0.0.3
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -63,6 +63,7 @@ TEST_REQUIREMENTS = (
     'influxdb',
     'libpurecoollink',
     'libsoundtouch',
+    'locationsharinglib',
     'mficlient',
     'numpy',
     'paho-mqtt',


### PR DESCRIPTION
With 3.0.2 locationsharinglib now the battery level and the charging attributes are available.

## Description:
This also fixes some other bugs, mentioned here: https://github.com/costastf/locationsharinglib/issues?q=is%3Aissue+is%3Aclosed

**Related issue (if applicable):** fixes #16947  #15076 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
